### PR TITLE
Improve performance by looking up strings with feature and set size

### DIFF
--- a/lib/simstring_pure.rb
+++ b/lib/simstring_pure.rb
@@ -182,8 +182,8 @@ module SimString
     def initialize(feature_extractor)
       @strings = Set.new
       @feature_extractor = feature_extractor
-      @feature_to_string_map = {}
       @feature_set_size_to_string_map = {}
+      @feature_set_size_and_feature_to_string_map = {}
     end
 
     def add(string)
@@ -197,10 +197,11 @@ module SimString
         @feature_set_size_to_string_map[feature_set_size] ||= Set.new
         @feature_set_size_to_string_map[feature_set_size] << string
 
-        # update @feature_to_string_map
+        # update @feature_set_size_and_feature_to_string_map
+        @feature_set_size_and_feature_to_string_map[feature_set_size] ||= {}
         features.each do |feature|
-          @feature_to_string_map[feature] ||= Set.new
-          @feature_to_string_map[feature] << string
+          @feature_set_size_and_feature_to_string_map[feature_set_size][feature] ||= Set.new
+          @feature_set_size_and_feature_to_string_map[feature_set_size][feature] << string
         end
       end
       nil
@@ -214,12 +215,9 @@ module SimString
       @feature_set_size_to_string_map.keys.max
     end
 
-    def lookup_strings_by_feature_set_size(size)
-      @feature_set_size_to_string_map[size] || Set.new
-    end
-
-    def lookup_strings_by_feature(feature)
-      @feature_to_string_map[feature] || Set.new
+    def lookup_strings_by_feature_set_size_and_feature(size, feature)
+      return Set.new if @feature_set_size_and_feature_to_string_map[size].nil?
+      @feature_set_size_and_feature_to_string_map[size][feature] || Set.new
     end
 
     def save(file_path)
@@ -310,7 +308,7 @@ module SimString
     # 1. the string has a feature set size equal to <y_size>
     # 2. the string's feature set contains the feature <feature>
     def get(db, y_size, feature)
-      db.lookup_strings_by_feature_set_size(y_size) & db.lookup_strings_by_feature(feature)
+      db.lookup_strings_by_feature_set_size_and_feature(y_size, feature)
     end
   end
 


### PR DESCRIPTION
Make `SimString::StringMatcher#search` about 75x faster by using hash object which has feature and size as keys, instead of using `Set#intersection` when looking up candidate strings.

# results
```sh
# before
$ ruby benchmark.rb
                                                                      user     system      total        real
SimString::Database#add (235544 lines)                          29.860000   0.490000  30.350000 ( 32.160920)
SimString::StringMatcher#search (1000 times)                   536.170000   4.870000 541.040000 (577.028125)

# after
$ git checkout nullnull/improve-performance
$ ruby benchmark.rb
                                                                      user     system      total        real
SimString::Database#add (235544 lines)                           28.650000   0.390000  29.040000 ( 29.693385)
SimString::StringMatcher#search (1000 times)                      7.700000   0.090000   7.790000 (  7.922363)
```


# benchmark.rb
```ruby
require_relative 'lib/simstring_pure'
require 'benchmark'

NUMBER_OF_TEST_STRINGS = 1000

ngram_builder = SimString::NGramBuilder.new(3)
db = SimString::Database.new(ngram_builder)
matcher = SimString::StringMatcher.new(db, SimString::CosineMeasure.new)
filename = 'wordlists/unabridged_dictionary.txt'

Benchmark.bm 100 do |r|
  r.report "SimString::Database\#add (#{File.readlines(filename).count} lines)" do
    File.readlines(filename).each { |line| db.add(line.strip) }
  end

  r.report "SimString::StringMatcher\#search (#{NUMBER_OF_TEST_STRINGS} times)" do
    File.readlines(filename).slice(0, NUMBER_OF_TEST_STRINGS).each do |line|
      matcher.search(line.strip, 0.6)
    end
  end
end
```

# test
```sh
$ rake
lib/simstring_pure.rb:176: warning: assigned but unused variable - m
Run options: --seed 14405

# Running:

...

Finished in 1.237981s, 2.4233 runs/s, 8.8854 assertions/s.
3 runs, 11 assertions, 0 failures, 0 errors, 0 skips
```